### PR TITLE
Fix gmusicapi version number comparisons

### DIFF
--- a/Plugin.pm
+++ b/Plugin.pm
@@ -58,7 +58,9 @@ sub initPlugin {
 	$VERSION = $class->_pluginDataFor('version');
 
 	# Chech version of gmusicapi first
-	if (!blessed($googleapi)) {
+	if (!blessed($googleapi) ||
+	    (version->parse(Plugins::GoogleMusic::GoogleAPI::get_version()) lt
+	     version->parse('4.0.0'))) {
 		$class->SUPER::initPlugin(
 			tag    => 'googlemusic',
 			feed   => \&badVersion,

--- a/Radio.pm
+++ b/Radio.pm
@@ -426,7 +426,8 @@ sub fetchStationTracks {
 
 	# Get new tracks for the station
 	eval {
-		if (Plugins::GoogleMusic::GoogleAPI::get_version() lt '4.1.0') {
+		if (version->parse(Plugins::GoogleMusic::GoogleAPI::get_version()) lt
+		    version->parse('4.1.0')) {
 			$googleTracks = $googleapi->get_station_tracks($station, $PLAYLIST_MAXLENGTH);
 		} else {
 			$googleTracks = $googleapi->get_station_tracks($station, $PLAYLIST_MAXLENGTH, $recentlyPlayed);


### PR DESCRIPTION
Use perl's version->parse() function to compare traditionally formatted, string-valued version numbers of the gmusicapi version. These commits enable the use of v 10.x of the gmusicapi package.

Note that I made a similar pull request in the nick7634/squeezebox-googlemusic repository before I found the existence of this one.