### PR TITLE
Use Slim::Player::Protocols::HTTPS on LMS 7.9.0 and greater

### DIFF
--- a/ProtocolHandler.pm
+++ b/ProtocolHandler.pm
@@ -2,7 +2,12 @@ package Plugins::GoogleMusic::ProtocolHandler;
 
 use strict;
 use warnings;
-use base qw(Slim::Player::Protocols::HTTP);
+
+# On LMS 7.9.0 and greater, https support is handled by the new
+# Slim::Player::Protocols::HTTPS library, which isn't available
+# on older versions
+use if (Slim::Utils::Versions->compareVersions($::VERSION, '7.9.0')) >= 0, base => qw(Slim::Player::Protocols::HTTPS);
+use if (Slim::Utils::Versions->compareVersions($::VERSION, '7.9.0')) < 0, base => qw(Slim::Player::Protocols::HTTP);
 
 use Scalar::Util qw(blessed);
 use Slim::Player::Playlist;


### PR DESCRIPTION
Fixes https://github.com/squeezebox-googlemusic/squeezebox-googlemusic/issues/14 and re-implements https://github.com/squeezebox-googlemusic/squeezebox-googlemusic/pull/16 so that the module `Slim::Player::Protocols::HTTPS` is used on LMS 7.9.0 and greater without impacting LMS 7.8.

Tested on Debian 8.0 with LMS versions 7.9.1 and 7.8.1 and found Google Play Music to work on both versions.