### PR TITLE
doc: remove stale version for gmusic api install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ systems to extend this howto.
    by running:
 
     ```
-    sudo pip install gmusicapi==10.1.2
+    sudo pip install gmusicapi
     ```
 
 1. The Google Music plugin requires the perl modules Inline::Python and IO::Socket::SSL


### PR DESCRIPTION
Install the latest gmusic api as older versions may not work.